### PR TITLE
disable verbose output from the hotpatch

### DIFF
--- a/cmd/hotdog-hotpatch/main.go
+++ b/cmd/hotdog-hotpatch/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/bottlerocket/hotdog"
 )
 
-var jvmOpts = []string{"-Xint", "-XX:+UseSerialGC"}
+var jvmOpts = []string{"-Xint", "-XX:+UseSerialGC", "-Dlog4jFixerVerbose=false"}
 var delays = []time.Duration{
 	0,
 	time.Second,


### PR DESCRIPTION
This commit modifies the hotpatch options so that does not inject output into stdout of the patched JVM.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.