### PR TITLE
close opened files

### DIFF
--- a/cmd/hotdog-cc-hook/main.go
+++ b/cmd/hotdog-cc-hook/main.go
@@ -99,10 +99,12 @@ func cp(in, out string) error {
 	if err != nil {
 		return err
 	}
+	defer inReader.Close()
 	outWriter, err := os.OpenFile(out, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0755)
 	if err != nil {
 		return err
 	}
+	defer outWriter.Close()
 	_, err = io.Copy(outWriter, inReader)
 	return err
 }

--- a/cmd/hotdog-hotpatch/main.go
+++ b/cmd/hotdog-hotpatch/main.go
@@ -48,6 +48,7 @@ func _main() error {
 	if err != nil {
 		return err
 	}
+	defer logFile.Close()
 	logger = log.New(logFile, "", log.LstdFlags|log.LUTC)
 	logger.Println("Starting hotpatch")
 
@@ -128,6 +129,7 @@ func findEUID(pid int) (uint32, uint32, error) {
 	if err != nil {
 		return 0, 0, err
 	}
+	defer status.Close()
 	scanner := bufio.NewScanner(status)
 	var (
 		uidLine string


### PR DESCRIPTION
*Description of changes:*
Hotdog opens a few files but failed to close them.  Given the short-lived nature of hotdog this is unlikely to be a problem, but it should still be corrected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
